### PR TITLE
gitignore udpate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ reports/
 java/emulatorcert.crt
 
 *.crt
+/.vscode/
+/.mvn/

--- a/archetype.properties
+++ b/archetype.properties
@@ -1,2 +1,2 @@
-excludePatterns=.m2/,.mvn/,*.iml
+excludePatterns=.m2/,.mvn/,*.iml,.vscode/
 archetype.filteredExtensions=java,xml,md,yml


### PR DESCRIPTION
updated gitignore with vscode and mvn folders to be excluded as well as the archetype properties for the vscode folder