### PR TITLE
fix(): mandatory upgrade to OWASP-dep-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <maven-surefire-phase>test</maven-surefire-phase>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-    <maven-owasp-dependency-check-plugin.version>10.0.4</maven-owasp-dependency-check-plugin.version>
+    <maven-owasp-dependency-check-plugin.version>12.1.0</maven-owasp-dependency-check-plugin.version>
     <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-site-plugin.version>3.20.0</maven-site-plugin.version>


### PR DESCRIPTION
Upgrades owasp-dependency-check to 12.1.0 as the NVD API spec changed. see: dependency-check/DependencyCheck#7463