### PR TITLE
Tidy up agentic config, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: "/java"
+    directory: "/"
     schedule:
       interval: weekly
       day: monday

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: "/"
+    directory: "/java"
     schedule:
       interval: weekly
       day: monday
       timezone: Europe/London
     open-pull-requests-limit: 50
+    assignees:
+      - RichardSlater
     rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/prompts/update-dependencies.prompt.md
+++ b/.github/prompts/update-dependencies.prompt.md
@@ -2,7 +2,7 @@
 mode: agent
 model: Auto (copilot)
 # prettier-ignore
-tools: ["maven/*", "github/pull_request_read", "github/list_pull_requests", "github/create_pull_request", "github/update_pull_request", "ado/advsec_get_alert_details", "ado/advsec_get_alerts", "ado/pipelines_get_builds", "ado/pipelines_get_build_log", "ado/pipelines_get_build_log_by_id", "ado/pipelines_get_build_status", "ado/pipelines_get_builds", "ado/pipelines_list_runs", "ado/pipelines_get_run"]
+tools: ['changes', 'vscodeAPI', 'codebase', 'maven/*', 'ado/advsec_get_alert_details', 'ado/advsec_get_alerts', 'ado/pipelines_get_build_log', 'ado/pipelines_get_build_log_by_id', 'ado/pipelines_get_build_status', 'ado/pipelines_get_builds', 'ado/pipelines_get_run', 'ado/pipelines_list_runs', 'github/add_issue_comment', 'github/create_pull_request', 'github/get_me', 'github/list_pull_requests', 'github/pull_request_read', 'github/update_pull_request']
 description: This prompt is designed to assist with managing and updating dependencies in a Maven project.
 ---
 

--- a/.github/prompts/update-dependencies.prompt.md
+++ b/.github/prompts/update-dependencies.prompt.md
@@ -10,7 +10,7 @@ description: This prompt is designed to assist with managing and updating depend
 
 You are an expert Java developer responsible for managing and updating dependencies in a Maven project. Your tasks include:
 
-1. Identifying outdated dependencies by checking the current versions against the latest available versions in the Maven Central Repository using the MCP Server tools.
+1. Identifying outdated dependencies by checking the current versions against the latest available versions in all configured Maven repositories (e.g., Maven Central, Sonatype, etc.) using the MCP Server tools.
 2. Creating and updating pull requests on GitHub to propose dependency updates, ensuring that each pull request includes a clear description of the changes made.
 3. Reviewing existing pull requests related to dependency updates to ensure they are up-to-date and do not conflict with other changes in the codebase.
 4. Monitoring Azure DevOps pipelines to ensure that builds pass successfully after dependency updates, and investigating any build failures that may arise due to these changes.

--- a/.github/prompts/update-dependencies.prompt.md
+++ b/.github/prompts/update-dependencies.prompt.md
@@ -1,0 +1,23 @@
+---
+mode: agent
+model: Auto (copilot)
+# prettier-ignore
+tools: ["maven/*", "github/pull_request_read", "github/list_pull_requests", "github/create_pull_request", "github/update_pull_request", "ado/advsec_get_alert_details", "ado/advsec_get_alerts", "ado/pipelines_get_builds", "ado/pipelines_get_build_log", "ado/pipelines_get_build_log_by_id", "ado/pipelines_get_build_status", "ado/pipelines_get_builds", "ado/pipelines_list_runs", "ado/pipelines_get_run"]
+description: This prompt is designed to assist with managing and updating dependencies in a Maven project.
+---
+
+## Instructions
+
+You are an expert Java developer responsible for managing and updating dependencies in a Maven project. Your tasks include:
+
+1. Identifying outdated dependencies by checking the current versions against the latest available versions in the Maven Central Repository using the MCP Server tools.
+2. Creating and updating pull requests on GitHub to propose dependency updates, ensuring that each pull request includes a clear description of the changes made.
+3. Reviewing existing pull requests related to dependency updates to ensure they are up-to-date and do not conflict with other changes in the codebase.
+4. Monitoring Azure DevOps pipelines to ensure that builds pass successfully after dependency updates, and investigating any build failures that may arise due to these changes.
+
+## What to avoid
+
+- Avoid making changes to the codebase that are unrelated to dependency management.
+- Do not create pull requests without proper descriptions of the changes made.
+- Do not rely on your own knowledge of dependency versions; always verify with the Maven Central Repository via the MCP Server.
+- Do not continue if the MCP server tools are unavailable or return errors.

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,26 @@
 {
+  "inputs": [
+    {
+      "id": "ado_org",
+      "type": "promptString",
+      "default": "ensonodigitaluk",
+      "description": "Azure DevOps organization name  (e.g. 'ensonodigitaluk')"
+    }
+  ],
   "servers": {
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "maven": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["mcp-maven-deps"]
+    },
+    "ado": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@azure-devops/mcp", "${input:ado_org}"]
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -13,9 +13,8 @@
       "url": "https://api.githubcopilot.com/mcp/"
     },
     "maven": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["mcp-maven-deps"]
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:latest"]
     },
     "ado": {
       "type": "stdio",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+  "java.configuration.updateBuildConfiguration": "interactive",
+  "debug.javascript.autoAttachFilter": "disabled"
 }


### PR DESCRIPTION
This PR tidies up the agentic configuration and Dependabot setup by correcting the Maven directory path, adding MCP server integrations for enhanced tooling, and configuring grouped dependency updates to reduce PR noise.

**Key Changes:**
- Corrected Dependabot Maven directory from "/" to "/java" to match actual project structure
- Added Maven and Azure DevOps MCP server configurations for improved agent capabilities
- Configured Dependabot to group low-risk (minor/patch) updates
