### PR TITLE
feat: Add Spring Cloud 2025.0.0 BOM and resource filtering for Spring Boot 3.5.x compatibility

### DIFF
--- a/docs/spring-boot-3.5-migration.md
+++ b/docs/spring-boot-3.5-migration.md
@@ -24,19 +24,9 @@ Update `spring.cloud.dependencies.version` to a version compatible with Spring B
 | 3.0.x, 3.1.x        | 2022.0.x (Kilburn)              |
 | 3.2.x               | 2023.0.x (Leyton)               |
 | 3.3.x, 3.4.x        | 2024.0.x                        |
-| 3.5.x               | 2025.0.x (when available)       |
+| 3.5.x               | 2025.0.x                        |
 
-**Workaround (current):**  
-Projects can disable the compatibility verifier in `application-test.yml`:
-
-```yaml
-spring:
-  cloud:
-    compatibility-verifier:
-      enabled: false
-```
-
-**Action Required:** Update parent POM to use Spring Cloud 2024.0.x or later (once 2025.0.x is available for Spring Boot 3.5.x support).
+**Action Required:** Update parent POM to use Spring Cloud 2025.0.x for Spring Boot 3.5.x support.
 
 ---
 

--- a/docs/spring-boot-3.5-migration.md
+++ b/docs/spring-boot-3.5-migration.md
@@ -1,0 +1,187 @@
+# Spring Boot 3.5.x Migration - Parent POM Requirements
+
+## Overview
+
+The `stacks-modules-parent:3.0.98` brings in Spring Boot 3.5.7, which introduces several breaking changes and compatibility issues that need to be addressed either in the parent POM or in downstream projects.
+
+## Issues Identified
+
+### 1. Spring Cloud Version Incompatibility
+
+**Problem:**  
+The current Spring Cloud version (`2022.0.4`) is incompatible with Spring Boot 3.5.7.
+
+```text
+Spring Boot [3.5.7] is not compatible with this Spring Cloud release train.
+Change Spring Boot version to one of the following versions [3.0.x, 3.1.x].
+```
+
+**Required Fix in Parent POM:**  
+Update `spring.cloud.dependencies.version` to a version compatible with Spring Boot 3.5.x:
+
+| Spring Boot Version | Compatible Spring Cloud Version |
+|---------------------|---------------------------------|
+| 3.0.x, 3.1.x        | 2022.0.x (Kilburn)              |
+| 3.2.x               | 2023.0.x (Leyton)               |
+| 3.3.x, 3.4.x        | 2024.0.x                        |
+| 3.5.x               | 2025.0.x (when available)       |
+
+**Workaround (current):**  
+Projects can disable the compatibility verifier in `application-test.yml`:
+
+```yaml
+spring:
+  cloud:
+    compatibility-verifier:
+      enabled: false
+```
+
+**Action Required:** Update parent POM to use Spring Cloud 2024.0.x or later (once 2025.0.x is available for Spring Boot 3.5.x support).
+
+---
+
+### 2. Spring Security Filter Chain Conflict
+
+**Problem:**  
+Spring Boot 3.5.x has stricter validation for Spring Security filter chains. Multiple `SecurityFilterChain` beans matching "any request" now throw an error:
+
+```text
+UnreachableFilterChainException: A filter chain that matches any request
+[...ApplicationConfig...] has already been configured, which means that this
+filter chain [...ApplicationNoSecurity...] will never get invoked.
+```
+
+**Required Fix:**  
+Security configurations with overlapping matchers must be mutually exclusive. If using profile-based security configurations:
+
+```java
+// Production security config - exclude from test profile
+@Configuration
+@EnableWebSecurity
+@Profile("!test")  // Add this annotation
+public class ApplicationConfig {
+    // ...
+}
+
+// Test security config - only active in test profile
+@Configuration
+@EnableWebSecurity
+@Profile("test")
+public class ApplicationNoSecurity {
+    // ...
+}
+```
+
+**Action Required:** This is a downstream project fix, but parent POM documentation should note this breaking change.
+
+---
+
+### 3. Bean Resolution Changes for Inheritance Hierarchies
+
+**Problem:**  
+Spring Boot 3.5.x has stricter bean resolution when multiple beans of the same type exist through inheritance:
+
+```text
+NoUniqueBeanDefinitionException: expected single matching bean but found 2:
+menuService, menuServiceV2
+```
+
+**Required Fix:**  
+When a service class is extended, the base class should be marked as `@Primary`:
+
+```java
+@Service
+@Primary  // Add this annotation
+public class MenuService {
+    // ...
+}
+
+@Service
+public class MenuServiceV2 extends MenuService {
+    // ...
+}
+```
+
+**Action Required:** This is a downstream project fix, but parent POM documentation should note this breaking change.
+
+---
+
+### 4. Maven Resource Filtering
+
+**Problem:**  
+Property placeholders like `@aws.profile.name@` in `application.yml` are not being replaced because Maven resource filtering is not enabled by default.
+
+```text
+Profile '@aws.profile.name@' must start and end with a letter or digit
+```
+
+**Required Fix in Projects:**  
+Enable resource filtering in `pom.xml`:
+
+```xml
+<build>
+  <resources>
+    <resource>
+      <directory>src/main/resources</directory>
+      <filtering>true</filtering>
+    </resource>
+  </resources>
+  <testResources>
+    <testResource>
+      <directory>src/test/resources</directory>
+      <filtering>true</filtering>
+    </testResource>
+  </testResources>
+</build>
+```
+
+**Action Required:** Consider adding this configuration to the parent POM so all child projects inherit it.
+
+---
+
+## Summary of Parent POM Changes Required
+
+### Critical (Must Fix) ✅ COMPLETED
+
+1. **Update Spring Cloud version** to be compatible with Spring Boot 3.5.x
+   - ~~Current: `2022.0.4`~~
+   - ✅ Updated to: `2025.0.0` (compatible with Spring Boot 3.5.x)
+   - Added `spring.cloud.dependencies.version` property
+   - Added Spring Cloud BOM to `dependencyManagement`
+
+### Recommended (Should Add) ✅ COMPLETED
+
+1. **Add default resource filtering configuration** so child projects don't need to configure it manually
+   - ✅ Added `<resources>` and `<testResources>` configuration with `<filtering>true</filtering>`
+
+2. **Update documentation** to note the following breaking changes for downstream projects:
+   - Security filter chain mutual exclusivity requirements
+   - Bean resolution changes for inheritance hierarchies
+   - Profile annotation requirements for conditional configurations
+
+### Temporary Workarounds Applied in stacks-java
+
+After updating to the new parent POM version, some workarounds may no longer be needed:
+
+| Issue                          | Workaround                      | File                                      |
+|--------------------------------|---------------------------------|-------------------------------------------|
+| Spring Cloud incompatibility   | Disabled compatibility verifier | `src/test/resources/application-test.yml` |
+| Security filter chain conflict | Added `@Profile("!test")`       | `ApplicationConfig.java`                  |
+| Bean resolution conflict       | Added `@Primary`                | `MenuService.java`                        |
+| Resource filtering             | Added filtering config          | `pom.xml`                                 |
+
+## Testing Verification
+
+After parent POM updates, verify with:
+
+```bash
+cd java
+./mvnw clean test
+./mvnw clean verify -P owasp-dependency-check
+```
+
+## References
+
+- [Spring Cloud Release Train Compatibility](https://spring.io/projects/spring-cloud#overview)
+- [Spring Boot 3.5 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes)
+- [Spring Security Filter Chain Configuration](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html)

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <snake.yaml.version>2.5</snake.yaml.version>
 
     <spring.boot.version>3.5.7</spring.boot.version>
+    <spring.cloud.dependencies.version>2025.0.0</spring.cloud.dependencies.version>
     <java.version>17</java.version>
 
     <!-- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327 -->
@@ -193,6 +194,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring.cloud.dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${logback.version}</version>
@@ -315,6 +323,20 @@
   </profiles>
 
   <build>
+    <!-- Resource filtering for property placeholder replacement (e.g., @property.name@) -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
     <pluginManagement>
       <!-- default plugin configuration goes here -->
       <plugins>


### PR DESCRIPTION
## Summary

This PR completes the Spring Boot 3.5.x migration by adding the necessary Spring Cloud BOM and resource filtering configuration to the parent POM.

## Changes

### Parent POM Updates

1. **Added Spring Cloud version property**
   - `spring.cloud.dependencies.version` set to `2025.0.0` (compatible with Spring Boot 3.5.7)

2. **Added Spring Cloud BOM to dependency management**
   ```xml
   <dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-dependencies</artifactId>
     <version>${spring.cloud.dependencies.version}</version>
     <type>pom</type>
     <scope>import</scope>
   </dependency>
   ```

3. **Added resource filtering configuration**
   - Enables Maven resource filtering for `src/main/resources` and `src/test/resources`
   - Allows property placeholder replacement (e.g., `@property.name@`) in resource files

### Documentation

- Added `docs/spring-boot-3.5-migration.md` documenting:
  - Spring Cloud version compatibility matrix
  - Breaking changes for downstream projects (security filter chains, bean resolution)
  - Workarounds and required fixes

## Why These Changes?

Spring Boot 3.5.7 requires Spring Cloud 2025.0.x for compatibility. The previous version (2022.0.4) used in some downstream projects caused startup failures with the compatibility verifier.

The resource filtering configuration ensures Maven property placeholders in application configuration files are properly replaced during build.

## Testing

- ✅ `./mvnw clean install` - Build successful
- Spring Cloud dependencies resolve correctly from Maven Central

## Downstream Project Notes

After upgrading to this parent POM version, downstream projects can:
1. Remove `spring.cloud.compatibility-verifier.enabled: false` workaround
2. Remove manual resource filtering configuration from their `pom.xml`

However, the following may still need attention in downstream projects:
- Security filter chain conflicts (add `@Profile` annotations for mutual exclusivity)
- Bean resolution conflicts with inheritance (add `@Primary` to base classes)

## References

- [Spring Cloud Release Train Compatibility](https://spring.io/projects/spring-cloud#overview)
- [Spring Boot 3.5 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes)