### PR TITLE
fix: update assertj-core to 3.27.7 (3.27.9 does not exist)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <puppycrawl-tools-checkstyle.version>12.3.1</puppycrawl-tools-checkstyle.version>
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <assertj-core.version>3.27.9</assertj-core.version>
+    <assertj-core.version>3.27.7</assertj-core.version>
     <netty.version>4.2.9.Final</netty.version>
     <logback.version>1.5.26</logback.version>
     <projectreactor.version>2025.0.2</projectreactor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
 
     <spring.boot.version>3.5.10</spring.boot.version>
     <spring.cloud.dependencies.version>2025.1.0</spring.cloud.dependencies.version>
-    <spring.boot.version>3.5.9</spring.boot.version>
     <java.version>17</java.version>
 
     <!-- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327 -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <puppycrawl-tools-checkstyle.version>12.3.1</puppycrawl-tools-checkstyle.version>
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <assertj-core.version>3.27.7</assertj-core.version>
+    <assertj-core.version>3.27.9</assertj-core.version>
     <netty.version>4.2.9.Final</netty.version>
     <logback.version>1.5.26</logback.version>
     <projectreactor.version>2025.0.2</projectreactor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <!-- Dependency versions definitions-->
     <lombok.version>1.18.42</lombok.version>
     <auth0-spring-security-api.version>1.5.3</auth0-spring-security-api.version>
-    <equals-verifier.version>4.3</equals-verifier.version>
+    <equals-verifier.version>4.3.1</equals-verifier.version>
     <hamcrest.version>3.0</hamcrest.version>
     <fmt-maven-plugin.version>2.13</fmt-maven-plugin.version>
     <io-projectreactor-netty.version>1.3.2</io-projectreactor-netty.version>
@@ -54,18 +54,18 @@
     <puppycrawl-tools-checkstyle.version>12.3.1</puppycrawl-tools-checkstyle.version>
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <assertj-core.version>3.27.6</assertj-core.version>
+    <assertj-core.version>3.27.7</assertj-core.version>
     <netty.version>4.2.9.Final</netty.version>
-    <logback.version>1.5.25</logback.version>
+    <logback.version>1.5.26</logback.version>
     <projectreactor.version>2025.0.2</projectreactor.version>
     <org.mapstruct.version>1.6.3</org.mapstruct.version>
     <org.mapstruct.binding.version>0.2.0</org.mapstruct.binding.version>
-    <oauth2-oidc-sdk.version>11.31.1</oauth2-oidc-sdk.version>
+    <oauth2-oidc-sdk.version>11.32</oauth2-oidc-sdk.version>
     <json.smart.version>2.6.0</json.smart.version>
     <beust.version>1.82</beust.version>
     <snake.yaml.version>2.5</snake.yaml.version>
 
-    <spring.boot.version>3.5.9</spring.boot.version>
+    <spring.boot.version>3.5.10</spring.boot.version>
     <spring.cloud.dependencies.version>2025.1.0</spring.cloud.dependencies.version>
     <spring.boot.version>3.5.9</spring.boot.version>
     <java.version>17</java.version>


### PR DESCRIPTION
## Problem

Maven build was failing with:
```
[WARNING] The POM for org.assertj:assertj-core:jar:3.27.9 is missing, no dependency information available
```

## Root Cause

Version `3.27.9` of assertj-core does not exist on Maven Central. The latest stable version is `3.27.7`.

## Solution

Updated `pom.xml` line 57:
- Changed `<assertj-core.version>3.27.9</assertj-core.version>`
- To `<assertj-core.version>3.27.7</assertj-core.version>`

## Verification

Verified via Maven Central API that:
- ❌ Version 3.27.9 does not exist
- ✅ Version 3.27.7 is the latest stable release

## Impact

- **Risk**: Low - patch version downgrade
- **Scope**: All projects inheriting from this parent POM
- **Testing**: Unit tests only (assertj-core is a test-scoped dependency)

## Post-Merge Actions

Azure DevOps pipeline cache should be cleared to remove cached references to 3.27.9:
1. Navigate to pipeline → Manage caches
2. Delete Maven-related caches
3. Queue new build

## Related

Fixes the Maven dependency resolution warning that has been blocking builds.