### PR TITLE
chore: normalize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,24 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      timezone: Europe/London
-    open-pull-requests-limit: 50
+      time: "04:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    reviewers:
+      - Ensono/stacks-maintainers
     assignees:
       - RichardSlater
-    rebase-strategy: disabled
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
     groups:
       low-risk:
         applies-to: version-updates
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
## Summary
- normalize .github/dependabot.yml to the team default schedule and metadata
- add grouped low-risk Maven updates with cooldown
- remove disabled rebasing and reduce the open PR limit

## Validation
- bash .github/skills/normalize-dependabot-config/scripts/validate-dependabot-schema.sh .github/dependabot.yml